### PR TITLE
Add resource lifecycle methods to Provider interface

### DIFF
--- a/tfprovider/internal/common/requests.go
+++ b/tfprovider/internal/common/requests.go
@@ -13,3 +13,68 @@ type ManagedResourceReadResponse struct {
 	RefreshedValue cty.Value
 	OpaquePrivate  []byte
 }
+
+// PlanResourceChangeRequest represents a request to plan a resource change.
+type PlanResourceChangeRequest struct {
+	TypeName         string
+	PriorState       cty.Value
+	ProposedNewState cty.Value
+	Config           cty.Value
+	PriorPrivate     []byte
+	ProviderMeta     cty.Value
+}
+
+// PlanResourceChangeResponse represents the response from planning a resource change.
+type PlanResourceChangeResponse struct {
+	PlannedState    cty.Value
+	RequiresReplace []cty.Path
+	PlannedPrivate  []byte
+}
+
+// ApplyResourceChangeRequest represents a request to apply a resource change.
+type ApplyResourceChangeRequest struct {
+	TypeName       string
+	PriorState     cty.Value
+	PlannedState   cty.Value
+	Config         cty.Value
+	PlannedPrivate []byte
+	ProviderMeta   cty.Value
+}
+
+// ApplyResourceChangeResponse represents the response from applying a resource change.
+type ApplyResourceChangeResponse struct {
+	NewState cty.Value
+	Private  []byte
+}
+
+// ReadResourceRequest represents a request to read a resource's current state.
+type ReadResourceRequest struct {
+	TypeName     string
+	CurrentState cty.Value
+	Private      []byte
+	ProviderMeta cty.Value
+}
+
+// ReadResourceResponse represents the response from reading a resource.
+type ReadResourceResponse struct {
+	NewState cty.Value
+	Private  []byte
+}
+
+// ImportResourceStateRequest represents a request to import a resource.
+type ImportResourceStateRequest struct {
+	TypeName string
+	ID       string
+}
+
+// ImportedResource represents a single imported resource in the response.
+type ImportedResource struct {
+	TypeName string
+	State    cty.Value
+	Private  []byte
+}
+
+// ImportResourceStateResponse represents the response from importing a resource.
+type ImportResourceStateResponse struct {
+	ImportedResources []ImportedResource
+}

--- a/tfprovider/internal/common/schema.go
+++ b/tfprovider/internal/common/schema.go
@@ -6,6 +6,7 @@ import (
 
 type Schema struct {
 	ProviderConfig       *tfschema.Block
+	ProviderMeta         *tfschema.Block
 	ManagedResourceTypes map[string]*ManagedResourceTypeSchema
 	DataResourceTypes    map[string]*DataResourceTypeSchema
 }

--- a/tfprovider/internal/protocol5/schema.go
+++ b/tfprovider/internal/protocol5/schema.go
@@ -79,6 +79,7 @@ func loadSchema(ctx context.Context, client tfplugin5.ProviderClient) (*common.S
 	}
 	var ret common.Schema
 	ret.ProviderConfig = decodeProviderSchemaBlock(resp.Provider.Block)
+	ret.ProviderMeta = decodeProviderSchemaBlock(resp.ProviderMeta.Block)
 	ret.ManagedResourceTypes = make(map[string]*common.ManagedResourceTypeSchema)
 	for name, raw := range resp.ResourceSchemas {
 		ret.ManagedResourceTypes[name] = &common.ManagedResourceTypeSchema{

--- a/tfprovider/internal/protocol6/provider.go
+++ b/tfprovider/internal/protocol6/provider.go
@@ -2,6 +2,7 @@ package protocol6
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/apparentlymart/terraform-provider/internal/tfplugin6"
@@ -139,6 +140,276 @@ func (p *Provider) ManagedResourceType(typeName string) common.ManagedResourceTy
 		typeName: typeName,
 		schema:   schema,
 	}
+}
+
+func (p *Provider) PlanResourceChange(ctx context.Context, req common.PlanResourceChangeRequest) (common.PlanResourceChangeResponse, common.Diagnostics) {
+	var diags common.Diagnostics
+
+	if moreDiags := p.requireConfigured(); moreDiags.HasErrors() {
+		return common.PlanResourceChangeResponse{}, moreDiags
+	}
+
+	schema, ok := p.schema.ManagedResourceTypes[req.TypeName]
+	if !ok {
+		diags = append(diags, common.Diagnostic{
+			Severity: common.Error,
+			Summary:  "Invalid resource type",
+			Detail:   fmt.Sprintf("The provider does not support resource type %q.", req.TypeName),
+		})
+		return common.PlanResourceChangeResponse{}, diags
+	}
+
+	priorDV, moreDiags := encodeDynamicValue(req.PriorState, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.PlanResourceChangeResponse{}, diags
+	}
+
+	proposedDV, moreDiags := encodeDynamicValue(req.ProposedNewState, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.PlanResourceChangeResponse{}, diags
+	}
+
+	configDV, moreDiags := encodeDynamicValue(req.Config, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.PlanResourceChangeResponse{}, diags
+	}
+
+	var providerMetaDV *tfplugin6.DynamicValue
+	if !req.ProviderMeta.IsNull() {
+		dv, moreDiags := encodeDynamicValue(req.ProviderMeta, p.schema.ProviderMeta)
+		diags = append(diags, moreDiags...)
+		if moreDiags.HasErrors() {
+			return common.PlanResourceChangeResponse{}, diags
+		}
+		providerMetaDV = dv
+	}
+
+	resp, err := p.client.PlanResourceChange(ctx, &tfplugin6.PlanResourceChange_Request{
+		TypeName:         req.TypeName,
+		PriorState:       priorDV,
+		ProposedNewState: proposedDV,
+		Config:           configDV,
+		PriorPrivate:     req.PriorPrivate,
+		ProviderMeta:     providerMetaDV,
+	})
+	diags = append(diags, common.RPCErrorDiagnostics(err)...)
+	if err != nil {
+		return common.PlanResourceChangeResponse{}, diags
+	}
+
+	diags = append(diags, decodeDiagnostics(resp.Diagnostics)...)
+
+	result := common.PlanResourceChangeResponse{
+		PlannedPrivate: resp.PlannedPrivate,
+	}
+
+	if resp.PlannedState != nil {
+		plannedState, moreDiags := decodeDynamicValue(resp.PlannedState, schema.Content)
+		diags = append(diags, moreDiags...)
+		result.PlannedState = plannedState
+	}
+
+	for _, attrPath := range resp.RequiresReplace {
+		path := decodeAttributePath(attrPath)
+		result.RequiresReplace = append(result.RequiresReplace, path)
+	}
+
+	return result, diags
+}
+
+func (p *Provider) ApplyResourceChange(ctx context.Context, req common.ApplyResourceChangeRequest) (common.ApplyResourceChangeResponse, common.Diagnostics) {
+	var diags common.Diagnostics
+
+	if moreDiags := p.requireConfigured(); moreDiags.HasErrors() {
+		return common.ApplyResourceChangeResponse{}, moreDiags
+	}
+
+	schema, ok := p.schema.ManagedResourceTypes[req.TypeName]
+	if !ok {
+		diags = append(diags, common.Diagnostic{
+			Severity: common.Error,
+			Summary:  "Invalid resource type",
+			Detail:   fmt.Sprintf("The provider does not support resource type %q.", req.TypeName),
+		})
+		return common.ApplyResourceChangeResponse{}, diags
+	}
+
+	priorDV, moreDiags := encodeDynamicValue(req.PriorState, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.ApplyResourceChangeResponse{}, diags
+	}
+
+	plannedDV, moreDiags := encodeDynamicValue(req.PlannedState, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.ApplyResourceChangeResponse{}, diags
+	}
+
+	configDV, moreDiags := encodeDynamicValue(req.Config, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.ApplyResourceChangeResponse{}, diags
+	}
+
+	var providerMetaDV *tfplugin6.DynamicValue
+	if !req.ProviderMeta.IsNull() {
+		dv, moreDiags := encodeDynamicValue(req.ProviderMeta, p.schema.ProviderMeta)
+		diags = append(diags, moreDiags...)
+		if moreDiags.HasErrors() {
+			return common.ApplyResourceChangeResponse{}, diags
+		}
+		providerMetaDV = dv
+	}
+
+	resp, err := p.client.ApplyResourceChange(ctx, &tfplugin6.ApplyResourceChange_Request{
+		TypeName:       req.TypeName,
+		PriorState:     priorDV,
+		PlannedState:   plannedDV,
+		Config:         configDV,
+		PlannedPrivate: req.PlannedPrivate,
+		ProviderMeta:   providerMetaDV,
+	})
+	diags = append(diags, common.RPCErrorDiagnostics(err)...)
+	if err != nil {
+		return common.ApplyResourceChangeResponse{}, diags
+	}
+
+	diags = append(diags, decodeDiagnostics(resp.Diagnostics)...)
+
+	result := common.ApplyResourceChangeResponse{
+		Private: resp.Private,
+	}
+
+	if resp.NewState != nil {
+		newState, moreDiags := decodeDynamicValue(resp.NewState, schema.Content)
+		diags = append(diags, moreDiags...)
+		result.NewState = newState
+	}
+
+	return result, diags
+}
+
+func (p *Provider) ReadResource(ctx context.Context, req common.ReadResourceRequest) (common.ReadResourceResponse, common.Diagnostics) {
+	var diags common.Diagnostics
+
+	if moreDiags := p.requireConfigured(); moreDiags.HasErrors() {
+		return common.ReadResourceResponse{}, moreDiags
+	}
+
+	schema, ok := p.schema.ManagedResourceTypes[req.TypeName]
+	if !ok {
+		diags = append(diags, common.Diagnostic{
+			Severity: common.Error,
+			Summary:  "Invalid resource type",
+			Detail:   fmt.Sprintf("The provider does not support resource type %q.", req.TypeName),
+		})
+		return common.ReadResourceResponse{}, diags
+	}
+
+	currentDV, moreDiags := encodeDynamicValue(req.CurrentState, schema.Content)
+	diags = append(diags, moreDiags...)
+	if moreDiags.HasErrors() {
+		return common.ReadResourceResponse{}, diags
+	}
+
+	var providerMetaDV *tfplugin6.DynamicValue
+	if !req.ProviderMeta.IsNull() {
+		dv, moreDiags := encodeDynamicValue(req.ProviderMeta, p.schema.ProviderMeta)
+		diags = append(diags, moreDiags...)
+		if moreDiags.HasErrors() {
+			return common.ReadResourceResponse{}, diags
+		}
+		providerMetaDV = dv
+	}
+
+	resp, err := p.client.ReadResource(ctx, &tfplugin6.ReadResource_Request{
+		TypeName:     req.TypeName,
+		CurrentState: currentDV,
+		Private:      req.Private,
+		ProviderMeta: providerMetaDV,
+	})
+	diags = append(diags, common.RPCErrorDiagnostics(err)...)
+	if err != nil {
+		return common.ReadResourceResponse{}, diags
+	}
+
+	diags = append(diags, decodeDiagnostics(resp.Diagnostics)...)
+
+	result := common.ReadResourceResponse{
+		Private: resp.Private,
+	}
+
+	if resp.NewState != nil {
+		newState, moreDiags := decodeDynamicValue(resp.NewState, schema.Content)
+		diags = append(diags, moreDiags...)
+		result.NewState = newState
+	}
+
+	return result, diags
+}
+
+func (p *Provider) ImportResourceState(ctx context.Context, req common.ImportResourceStateRequest) (common.ImportResourceStateResponse, common.Diagnostics) {
+	var diags common.Diagnostics
+
+	if moreDiags := p.requireConfigured(); moreDiags.HasErrors() {
+		return common.ImportResourceStateResponse{}, moreDiags
+	}
+
+	schema, ok := p.schema.ManagedResourceTypes[req.TypeName]
+	if !ok {
+		diags = append(diags, common.Diagnostic{
+			Severity: common.Error,
+			Summary:  "Invalid resource type",
+			Detail:   fmt.Sprintf("The provider does not support resource type %q.", req.TypeName),
+		})
+		return common.ImportResourceStateResponse{}, diags
+	}
+
+	resp, err := p.client.ImportResourceState(ctx, &tfplugin6.ImportResourceState_Request{
+		TypeName: req.TypeName,
+		Id:       req.ID,
+	})
+	diags = append(diags, common.RPCErrorDiagnostics(err)...)
+	if err != nil {
+		return common.ImportResourceStateResponse{}, diags
+	}
+
+	diags = append(diags, decodeDiagnostics(resp.Diagnostics)...)
+
+	result := common.ImportResourceStateResponse{}
+
+	for _, imported := range resp.ImportedResources {
+		importedSchema := schema
+		if imported.TypeName != req.TypeName {
+			// Check if the returned type name is valid
+			if altSchema, ok := p.schema.ManagedResourceTypes[imported.TypeName]; ok {
+				importedSchema = altSchema
+			} else {
+				diags = append(diags, common.Diagnostic{
+					Severity: common.Error,
+					Summary:  "Invalid imported resource type",
+					Detail:   fmt.Sprintf("The provider returned an invalid resource type %q during import.", imported.TypeName),
+				})
+				continue
+			}
+		}
+
+		state, moreDiags := decodeDynamicValue(imported.State, importedSchema.Content)
+		diags = append(diags, moreDiags...)
+		if !moreDiags.HasErrors() {
+			result.ImportedResources = append(result.ImportedResources, common.ImportedResource{
+				TypeName: imported.TypeName,
+				State:    state,
+				Private:  imported.Private,
+			})
+		}
+	}
+
+	return result, diags
 }
 
 func (p *Provider) Close() error {

--- a/tfprovider/internal/protocol6/schema.go
+++ b/tfprovider/internal/protocol6/schema.go
@@ -79,6 +79,7 @@ func loadSchema(ctx context.Context, client tfplugin6.ProviderClient) (*common.S
 	}
 	var ret common.Schema
 	ret.ProviderConfig = decodeProviderSchemaBlock(resp.Provider.Block)
+	ret.ProviderMeta = decodeProviderSchemaBlock(resp.ProviderMeta.Block)
 	ret.ManagedResourceTypes = make(map[string]*common.ManagedResourceTypeSchema)
 	for name, raw := range resp.ResourceSchemas {
 		ret.ManagedResourceTypes[name] = &common.ManagedResourceTypeSchema{

--- a/tfprovider/tfprovider.go
+++ b/tfprovider/tfprovider.go
@@ -58,6 +58,31 @@ type Provider interface {
 	// method. An unconfigured provider always returns nil.
 	ManagedResourceType(name string) ManagedResourceType
 
+	// PlanResourceChange produces a plan for changing a managed resource
+	// from its prior state to a proposed new state.
+	//
+	// The provider must be configured using [Configure] before calling this
+	// method.
+	PlanResourceChange(ctx context.Context, req common.PlanResourceChangeRequest) (common.PlanResourceChangeResponse, Diagnostics)
+
+	// ApplyResourceChange applies a planned change to a managed resource.
+	//
+	// The provider must be configured using [Configure] before calling this
+	// method.
+	ApplyResourceChange(ctx context.Context, req common.ApplyResourceChangeRequest) (common.ApplyResourceChangeResponse, Diagnostics)
+
+	// ReadResource reads current state of a managed resource.
+	//
+	// The provider must be configured using [Configure] before calling this
+	// method.
+	ReadResource(ctx context.Context, req common.ReadResourceRequest) (common.ReadResourceResponse, Diagnostics)
+
+	// ImportResourceState imports an existing resource into Terraform state.
+	//
+	// The provider must be configured using [Configure] before calling this
+	// method.
+	ImportResourceState(ctx context.Context, req common.ImportResourceStateRequest) (common.ImportResourceStateResponse, Diagnostics)
+
 	// Close kills the child process for this provider plugin, rendering the
 	// reciever unusable. Any further calls on the object after Close returns
 	// cause undefined behavior.


### PR DESCRIPTION
Add PlanResourceChange, ApplyResourceChange, ReadResource, and ImportResourceState methods to the Provider interface and implement them in both protocol v5 and v6 providers.

Changes:
- Add new request/response types in common package
- Implement all four methods in protocol5 and protocol6 providers
- Add ProviderMeta field to Schema struct for provider metadata support
- Update schema loading to handle ProviderMeta in both protocols